### PR TITLE
Semi-colon for concatenation and check for nodes.

### DIFF
--- a/helios-audio-mixer.js
+++ b/helios-audio-mixer.js
@@ -1268,7 +1268,7 @@ var heliosAudioMixer = (function() {
         this.options.gain = val
       }
 
-      if(this.status.playing && this.nodes.gain) {
+      if(this.status.playing && this.nodes && this.nodes.gain) {
 
         if(!Detect.webAudio)
           this.element.volume = this.options.gain * this.mix.gain
@@ -1398,4 +1398,4 @@ var heliosAudioMixer = (function() {
 
   return Mix
 
-}())
+}());


### PR DESCRIPTION
Hey Iain,

Here are a couple small fixes I've implemented in a personal project. You can merge in at your convenience if you like them. (I have only been working in `helios-audio-mixer.js`).

Fixes are:
* Added a semi-colon at the end of the file to avoid errors when concatenating. (Semi-colons should be added throughout the file at some point).
* Line `1271`, added an extra condition to make sure `this.nodes` exists before checking for `this.nodes.gain`. I was getting multiple errors because the computer couldn't get gain of undefined.