### PR TITLE
Add options and comment out broken function call.

### DIFF
--- a/helios-audio-mixer.js
+++ b/helios-audio-mixer.js
@@ -686,8 +686,9 @@ var heliosAudioMixer = (function() {
      */
     if (_this.options.looping) { _this.element.loop = true; }
     if (_this.options.muted) { _this.element.muted = true; }
-
-    // _this.source = _this.mix.context.createMediaElementSource(_this.element);
+    
+    if(_this.mix.context)
+      _this.source = _this.mix.context.createMediaElementSource(_this.element);
 
     var ready = function() {
       _this.status.loaded = true

--- a/helios-audio-mixer.js
+++ b/helios-audio-mixer.js
@@ -681,7 +681,13 @@ var heliosAudioMixer = (function() {
     _this.element = _this.options.source
     _this.options.source = _this.element.src
 
-    _this.source = _this.mix.context.createMediaElementSource(_this.element);
+    /**
+     * Add options if they're set.
+     */
+    if (_this.options.looping) { _this.element.loop = true; }
+    if (_this.options.muted) { _this.element.muted = true; }
+
+    // _this.source = _this.mix.context.createMediaElementSource(_this.element);
 
     var ready = function() {
       _this.status.loaded = true


### PR DESCRIPTION
Have been working on HTML5 mode (for IE) and noticed a couple of issues.

* Commented out call to `_this.mix.context.createMediaElementSource(_this.element)` on line `690`. It looks like that function no longer exists and this was causing an error.
* Added in options for looping and muted (if either of those are set in the options object).